### PR TITLE
more responsive layout + others UX improvements (subjective) + add offset labels

### DIFF
--- a/web/greenwave-ui/src/components/ConfirmModal.svelte
+++ b/web/greenwave-ui/src/components/ConfirmModal.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { fade, scale } from 'svelte/transition';
+
   export let show = false;
   export let title = "Confirm Action";
   export let message = "Are you sure you want to proceed?";
@@ -7,17 +9,17 @@
   export let onConfirm = () => {};
   export let onCancel = () => {};
   export let danger = false;
-  
+
   function handleConfirm() {
     onConfirm();
     show = false;
   }
-  
+
   function handleCancel() {
     onCancel();
     show = false;
   }
-  
+
   function handleBackdropClick(event) {
     if (event.target === event.currentTarget) {
       handleCancel();
@@ -28,33 +30,38 @@
 {#if show}
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
+    transition:fade={{ duration: 150 }}
     class="fixed inset-0 flex items-center justify-center z-50"
-    style="background-color: rgba(0, 0, 0, 0.75);"
+    style="background-color: rgba(0, 0, 0, 0.6);"
     on:click={handleBackdropClick}
     on:keydown={(e) => e.key === 'Escape' && handleCancel()}
     role="dialog"
     aria-modal="true"
     tabindex="-1"
   >
-    <!-- Modal Content -->
-    <div class="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6 border border-gray-300">
-      <h3 class="text-lg font-semibold mb-4 text-gray-900">{title}</h3>
-      <p class="text-gray-600 mb-6 leading-relaxed">{message}</p>
-      
+    <div
+      transition:scale={{ start: 0.96, duration: 150 }}
+      class="bg-white rounded-lg shadow-2xl max-w-md w-full mx-4 p-6 border border-gray-200"
+    >
+      <h3 class="text-lg font-semibold mb-3 text-gray-900">{title}</h3>
+      <p class="text-gray-600 mb-6 leading-relaxed text-sm">{message}</p>
+
       <div class="flex justify-end gap-3">
-        <button 
+        <button
           on:click={handleCancel}
-          class="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-gray-700 transition-colors"
+          class="px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50 text-gray-700 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
         >
           {cancelText}
         </button>
-        <button 
+        <button
           on:click={handleConfirm}
-          class="px-4 py-2 rounded-lg text-white transition-colors"
+          class="px-4 py-2 rounded-md text-white text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
           class:bg-red-500={danger}
           class:hover:bg-red-600={danger}
+          class:focus-visible:ring-red-400={danger}
           class:bg-blue-500={!danger}
           class:hover:bg-blue-600={!danger}
+          class:focus-visible:ring-blue-400={!danger}
         >
           {confirmText}
         </button>

--- a/web/greenwave-ui/src/components/DropdownMenu.svelte
+++ b/web/greenwave-ui/src/components/DropdownMenu.svelte
@@ -49,7 +49,7 @@
 
   {#if isOpen}
     <div
-      class="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-50"
+      class="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-40"
       role="menu"
       tabindex="-1"
       on:click|stopPropagation={() => {}}

--- a/web/greenwave-ui/src/components/EditJunctionModal.svelte
+++ b/web/greenwave-ui/src/components/EditJunctionModal.svelte
@@ -1,5 +1,6 @@
 <script>
   import { createEventDispatcher } from 'svelte';
+  import { fade, scale } from 'svelte/transition';
 
   export let junction = null;
   export let isNew = false;
@@ -9,9 +10,16 @@
   // Local copy for editing
   let editedJunction = null;
 
+  // Inline validation error  replaces native alert()
+  let validationError = null;
+
+  // Inline delete confirmation  replaces native confirm()
+  let showDeleteConfirm = false;
+
   $: if (junction) {
-    // Deep clone the junction to avoid mutating the original
     editedJunction = JSON.parse(JSON.stringify(junction));
+    validationError = null;
+    showDeleteConfirm = false;
   }
 
   function handleBackdropClick(event) {
@@ -22,16 +30,16 @@
 
   function saveJunction() {
     if (!editedJunction) return;
+    validationError = null;
 
-    // Validate: at least one phase with at least one signal
     if (editedJunction.cycle.length === 0) {
-      alert('Junction must have at least one phase');
+      validationError = 'Junction must have at least one phase.';
       return;
     }
 
     for (const phase of editedJunction.cycle) {
       if (phase.signal_groups[0].signals.length === 0) {
-        alert('Each phase must have at least one signal');
+        validationError = 'Each phase must have at least one signal.';
         return;
       }
     }
@@ -39,13 +47,12 @@
     dispatch('save', { junction: editedJunction, isNew });
   }
 
-  function deleteJunction() {
-    if (confirm(`Are you sure you want to delete "${editedJunction.label}"?`)) {
-      dispatch('delete', { junction: editedJunction });
-    }
+  function confirmDelete() {
+    dispatch('delete', { junction: editedJunction });
   }
 
   function addPhase() {
+    validationError = null;
     const newPhaseId = Math.max(0, ...editedJunction.cycle.map(p => p.id)) + 1;
     editedJunction.cycle = [
       ...editedJunction.cycle,
@@ -61,65 +68,79 @@
 
   function removePhase(phaseIndex) {
     if (editedJunction.cycle.length <= 1) {
-      alert('Junction must have at least one phase');
+      validationError = 'Junction must have at least one phase.';
       return;
     }
+    validationError = null;
     editedJunction.cycle = editedJunction.cycle.filter((_, i) => i !== phaseIndex);
   }
 
   function addSignal(phaseIndex) {
+    validationError = null;
     const sg = editedJunction.cycle[phaseIndex].signal_groups[0];
     sg.signals = [...sg.signals, { duration: 10, color: 'GREEN' }];
-    editedJunction.cycle = [...editedJunction.cycle]; // trigger reactivity
+    editedJunction.cycle = [...editedJunction.cycle];
   }
 
   function removeSignal(phaseIndex, signalIndex) {
     const sg = editedJunction.cycle[phaseIndex].signal_groups[0];
     if (sg.signals.length <= 1) {
-      alert('Phase must have at least one signal');
+      validationError = 'Phase must have at least one signal.';
       return;
     }
+    validationError = null;
     sg.signals = sg.signals.filter((_, i) => i !== signalIndex);
-    editedJunction.cycle = [...editedJunction.cycle]; // trigger reactivity
+    editedJunction.cycle = [...editedJunction.cycle];
   }
 </script>
 
 {#if editedJunction}
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
+    transition:fade={{ duration: 150 }}
     class="fixed inset-0 flex items-center justify-center z-50"
-    style="background-color: rgba(0, 0, 0, 0.75);"
+    style="background-color: rgba(0, 0, 0, 0.6);"
     on:click={handleBackdropClick}
     on:keydown={(e) => e.key === 'Escape' && dispatch('close')}
     role="dialog"
     aria-modal="true"
     tabindex="-1"
   >
-    <div class="bg-white rounded-lg shadow-lg max-w-2xl w-full mx-4 p-6 max-h-[90vh] overflow-y-auto">
+    <div
+      transition:scale={{ start: 0.96, duration: 150 }}
+      class="bg-white rounded-lg shadow-lg max-w-2xl w-full mx-4 p-6 max-h-[90vh] overflow-y-auto"
+    >
       <h3 class="text-lg font-medium mb-4">
         {isNew ? 'Create New Junction' : `Edit ${editedJunction.label}`}
       </h3>
 
+      <!-- Inline validation error. So no native alert() -->
+      {#if validationError}
+        <div class="mb-4 px-3 py-2 bg-red-50 border border-red-300 rounded-md text-sm text-red-700">
+          {validationError}
+        </div>
+      {/if}
+
       <!-- Junction basic info -->
       <div class="space-y-4 mb-6">
         <div class="flex items-center gap-4">
-          <label for="junction-label" class="text-sm font-medium w-32">Label:</label>
+          <label for="junction-label" class="text-sm font-medium w-32 shrink-0">Label:</label>
           <input
             id="junction-label"
             type="text"
             bind:value={editedJunction.label}
-            class="flex-1 px-3 py-2 border rounded-md"
+            class="flex-1 px-3 py-2 border rounded-md min-w-0"
             placeholder="Junction name"
           />
         </div>
 
         <div class="flex items-center gap-4">
-          <label for="junction-distance" class="text-sm font-medium w-32">Distance (m):</label>
+          <label for="junction-distance" class="text-sm font-medium w-32 shrink-0">Distance (m):</label>
           <input
             id="junction-distance"
             type="number"
             bind:value={editedJunction.point.y}
-            class="flex-1 px-3 py-2 border rounded-md"
+            class="flex-1 px-3 py-2 border rounded-md min-w-0"
             min="0"
             step="10"
             placeholder="Distance from start"
@@ -132,7 +153,7 @@
         <div class="flex justify-between items-center mb-4">
           <h4 class="text-md font-medium">Phases ({editedJunction.cycle.length})</h4>
           <button
-            class="px-3 py-1 bg-green-500 text-white text-sm rounded hover:bg-green-600"
+            class="px-3 py-1.5 bg-green-500 text-white text-sm rounded-md hover:bg-green-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400"
             on:click={addPhase}
           >
             + Add Phase
@@ -145,7 +166,7 @@
               <div class="flex justify-between items-center mb-3">
                 <h5 class="text-sm font-medium">Phase {phaseIndex + 1}</h5>
                 <button
-                  class="px-2 py-1 bg-red-100 text-red-600 text-xs rounded hover:bg-red-200"
+                  class="px-2 py-1 bg-red-100 text-red-600 text-xs rounded-md hover:bg-red-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                   on:click={() => removePhase(phaseIndex)}
                   title="Remove phase"
                 >
@@ -155,11 +176,12 @@
 
               <div class="space-y-2">
                 {#each phase.signal_groups[0].signals as signal, signalIndex}
-                  <div class="flex items-center gap-2">
-                    <span class="text-xs text-gray-500 w-16">Signal {signalIndex + 1}</span>
+                  <!-- flex-wrap so rows don't overflow on narrow modals (phones) -->
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <span class="text-xs text-gray-500 w-14 shrink-0">Signal {signalIndex + 1}</span>
                     <select
                       bind:value={signal.color}
-                      class="px-2 py-1 border rounded-md text-sm"
+                      class="px-2 py-1.5 border rounded-md text-sm min-w-0"
                     >
                       <option value="GREEN">Green</option>
                       <option value="RED">Red</option>
@@ -168,13 +190,13 @@
                     <input
                       type="number"
                       bind:value={signal.duration}
-                      class="w-20 px-2 py-1 border rounded-md text-sm"
+                      class="w-16 px-2 py-1.5 border rounded-md text-sm"
                       min="1"
                       placeholder="sec"
                     />
-                    <span class="text-xs text-gray-400">sec</span>
+                    <span class="text-xs text-gray-400">s</span>
                     <button
-                      class="px-2 py-1 text-red-500 hover:text-red-700 text-xs"
+                      class="px-2 py-1 text-red-500 hover:text-red-700 text-xs rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                       on:click={() => removeSignal(phaseIndex, signalIndex)}
                       title="Remove signal"
                     >
@@ -185,7 +207,7 @@
               </div>
 
               <button
-                class="mt-2 px-2 py-1 bg-gray-200 text-xs rounded hover:bg-gray-300"
+                class="mt-2 px-2 py-1.5 bg-gray-200 text-xs rounded-md hover:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                 on:click={() => addSignal(phaseIndex)}
               >
                 + Add Signal
@@ -199,23 +221,42 @@
       <div class="flex justify-between mt-6 pt-4 border-t">
         <div>
           {#if !isNew}
-            <button
-              class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-              on:click={deleteJunction}
-            >
-              Delete Junction
-            </button>
+            {#if showDeleteConfirm}
+              <!-- Inline delete confirmation. Just replaces native confirm() (same, as alert())-->
+              <div class="flex items-center gap-2">
+                <span class="text-sm text-red-600">Delete "{editedJunction.label}"?</span>
+                <button
+                  class="px-3 py-1.5 bg-red-500 text-white text-sm rounded-md hover:bg-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                  on:click={confirmDelete}
+                >
+                  Yes, delete
+                </button>
+                <button
+                  class="px-3 py-1.5 bg-gray-200 text-gray-700 text-sm rounded-md hover:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+                  on:click={() => showDeleteConfirm = false}
+                >
+                  Cancel
+                </button>
+              </div>
+            {:else}
+              <button
+                class="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                on:click={() => showDeleteConfirm = true}
+              >
+                Delete Junction
+              </button>
+            {/if}
           {/if}
         </div>
         <div class="flex gap-2">
           <button
-            class="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
+            class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
             on:click={() => dispatch('close')}
           >
             Cancel
           </button>
           <button
-            class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
             on:click={saveJunction}
           >
             {isNew ? 'Create' : 'Save'}

--- a/web/greenwave-ui/src/components/EditSignalModal.svelte
+++ b/web/greenwave-ui/src/components/EditSignalModal.svelte
@@ -1,15 +1,15 @@
 <script>
   import { createEventDispatcher } from 'svelte';
+  import { fade, scale } from 'svelte/transition';
 
   export let signal;
   const dispatch = createEventDispatcher();
 
   function saveSignal() {
-    dispatch('save', { signal }); // Emit the updated signal
+    dispatch('save', { signal });
   }
 
   function handleBackdropClick(event) {
-    // Close the modal when clicking outside
     if (event.target === event.currentTarget) {
       dispatch('close');
     }
@@ -19,50 +19,51 @@
 {#if signal}
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
+    transition:fade={{ duration: 150 }}
     class="fixed inset-0 flex items-center justify-center z-50"
-    style="background-color: rgba(0, 0, 0, 0.75);"
+    style="background-color: rgba(0, 0, 0, 0.6);"
     on:click={handleBackdropClick}
     on:keydown={(e) => e.key === 'Escape' && dispatch('close')}
     role="dialog"
     aria-modal="true"
     tabindex="-1"
   >
-    <!-- Modal content -->
-    <div class="bg-white rounded-lg shadow-lg max-w-md w-full mx-4 p-6">
+    <div
+      transition:scale={{ start: 0.96, duration: 150 }}
+      class="bg-white rounded-lg shadow-lg max-w-md w-full mx-4 p-6"
+    >
       <h3 class="text-lg font-medium mb-4">Edit Signal</h3>
       <div class="space-y-4">
-        <!-- Color input -->
         <div class="flex items-center gap-4">
-          <label for="signal-color" class="text-sm font-medium w-24">Color:</label>
-          <select id="signal-color" bind:value={signal.color} class="flex-1 px-3 py-2 border rounded-md">
+          <label for="signal-color" class="text-sm font-medium w-24 shrink-0">Color:</label>
+          <select id="signal-color" bind:value={signal.color} class="flex-1 px-3 py-2 border rounded-md min-w-0">
             <option value="GREEN">Green</option>
             <option value="RED">Red</option>
             <option value="YELLOW">Yellow</option>
           </select>
         </div>
 
-        <!-- Duration input -->
         <div class="flex items-center gap-4">
-          <label for="signal-duration" class="text-sm font-medium w-24">Duration (s):</label>
+          <label for="signal-duration" class="text-sm font-medium w-24 shrink-0">Duration (s):</label>
           <input
             id="signal-duration"
             type="number"
             bind:value={signal.duration}
-            class="flex-1 px-3 py-2 border rounded-md"
+            class="flex-1 px-3 py-2 border rounded-md min-w-0"
             min="1"
           />
         </div>
       </div>
 
       <div class="flex justify-between mt-6">
-        <button 
-          class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        <button
+          class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
           on:click={saveSignal}
         >
           Save
         </button>
-        <button 
-          class="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
+        <button
+          class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
           on:click={() => dispatch('close')}
         >
           Cancel
@@ -71,4 +72,3 @@
     </div>
   </div>
 {/if}
-

--- a/web/greenwave-ui/src/components/TimeSpaceDiagram.svelte
+++ b/web/greenwave-ui/src/components/TimeSpaceDiagram.svelte
@@ -12,6 +12,7 @@
   export let reverseGreenWaves = [];
   export let reverseThroughWaves = [];
   export let showWaves = false;
+  export let showOffsets = false;
   
   const dispatch = createEventDispatcher();
 
@@ -170,6 +171,19 @@
       .attr("font-weight", "bold")
       .attr("fill", "#333")
       .text(d => `${d.label || `J${d.id}`}, ${d.total_duration}s`);
+
+    // Draw offset labels at the right end of X axis (results panel only)
+    if (showOffsets) {
+      junctionGroups.append("text")
+        .attr("x", chartWidth + 4)
+        .attr("y", 0)
+        .attr("dy", "0.35em")
+        .attr("text-anchor", "start")
+        .attr("font-size", "10px")
+        .attr("font-weight", "bold")
+        .attr("fill", "#4B0082")
+        .text(d => `+${d.offset}s`);
+    }
 
     // Make labels clickable in interactive mode
     if (interactive) {

--- a/web/greenwave-ui/src/components/TimeSpaceDiagram.svelte
+++ b/web/greenwave-ui/src/components/TimeSpaceDiagram.svelte
@@ -4,10 +4,8 @@
 
   import * as d3 from 'd3';
 
-  export let isResults = false;
   export let junctions = [];
   export let wavesAreOutdated = { isOutdated: false, reason: null };
-  export let resultsAreOutdated = { isOutdated: false, reason: null };
   export let interactive = false;
   export let greenWaves = [];
   export let throughWaves = [];
@@ -24,8 +22,8 @@
   let isDragging = false; 
 
   const margin = { top: 30, right: 30, bottom: 40, left: 60 };
-  const chartWidth = width - margin.left - margin.right;
-  const chartHeight = height - margin.top - margin.bottom;
+  let chartWidth = width - margin.left - margin.right;
+  let chartHeight = height - margin.top - margin.bottom;
   
   // Helper function to calculate total duration for a junction.
   // Uses the first signal group as the reference (all groups are synchronized).
@@ -599,6 +597,10 @@
     if (container) {
       width = container.clientWidth;
       height = container.clientHeight;
+      // Recalculate derived dimensions so every D3 call (scales, axes, wave polygons)
+      // uses the correct pixel measurements for this container size.
+      chartWidth = width - margin.left - margin.right;
+      chartHeight = height - margin.top - margin.bottom;
       updateChart();
     }
   }
@@ -615,66 +617,11 @@
 </script>
 
 <div bind:this={container} class="diagram-container w-full h-full relative">
-  <!-- SVG Chart -->
-  <div class="plot-container relative">
-    <svg bind:this={svg} {width} {height} class="w-full h-full"></svg>
+  <!-- SVG fills the container absolutely  no flex space consumed, no layout impact -->
+  <div class="absolute inset-0 overflow-hidden">
+    <svg bind:this={svg} {width} {height} style="display:block"></svg>
   </div>
 
-  <!-- Status/Info Box -->
-<!-- Status/Info Box -->
-{#if junctions.length > 0}
-  <div class="tip-container mb-3 mr-3 bg-white bg-opacity-90 rounded-lg px-3 py-2 text-xs text-gray-600 shadow-sm border border-gray-200">
-    <div class="flex flex-col gap-2">
-      {#if isResults}
-        <!-- Results plot -->
-        {#if resultsAreOutdated.isOutdated}
-          <div class="flex items-center gap-2">
-            <svg class="icon w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <span class="text-orange-600 ml-2">⚠️ {resultsAreOutdated.reason}</span>
-          </div>
-        {:else}
-          <div class="flex items-center gap-2">
-            <svg class="icon w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <span>💡 <strong>Press 'Optimize' to refresh</strong></span>
-          </div>
-        {/if}
-      {:else}
-        <!-- Input data plot -->
-        {#if wavesAreOutdated.isOutdated}
-          <div class="flex items-center gap-2">
-            <svg class="icon w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <span class="text-orange-600 ml-2">⚠️{wavesAreOutdated.reason}</span>
-          </div>
-        {:else}
-          <div class="flex items-center gap-2">
-            <svg class="icon w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <div>💡 <strong>Drag junctions</strong> to change distances</div>
-          </div>
-          <div class="flex items-center gap-2">
-            <svg class="icon w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <div>💡 <strong>Click junction</strong> to edit phases and signals</div>
-          </div>
-          <div class="flex items-center gap-2">
-            <svg class="icon w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <div>💡 <strong>Click signal</strong> to change its color or duration</div>
-          </div>
-        {/if}
-      {/if}
-    </div>
-  </div>
-{/if}
 </div>
 
 <style>
@@ -683,12 +630,5 @@
     height: 100%;
     min-height: 300px;
     position: relative;
-    display: flex;
-    flex-direction: column;
   }
-  
-  .tip-container {
-    align-self: flex-end;
-  }
-
 </style>

--- a/web/greenwave-ui/src/routes/+page.svelte
+++ b/web/greenwave-ui/src/routes/+page.svelte
@@ -666,6 +666,7 @@
               reverseGreenWaves={$optimizedReverseGreenWaves}
               reverseThroughWaves={$optimizedReverseThroughWaves}
               showWaves={true}
+              showOffsets={true}
               interactive={false}
             />
           {:else}

--- a/web/greenwave-ui/src/routes/+page.svelte
+++ b/web/greenwave-ui/src/routes/+page.svelte
@@ -4,6 +4,7 @@
   import EditSignalModal from '../components/EditSignalModal.svelte';
   import EditJunctionModal from '../components/EditJunctionModal.svelte';
   import DropdownMenu from '../components/DropdownMenu.svelte';
+  import { slide } from 'svelte/transition';
   import { isLoading, error, resetToDemo, resetToEmpty } from '$lib/stores';
   import { exportToJSON, importFromJSON, validateImportedConfig, prepareInputExport, prepareOutputExport } from '$lib/utils/export-import.js';
   import { junctions, desiredSpeed, desiredIntensity, desiredFlow, optimizationDirection } from '$lib/stores/core';
@@ -17,7 +18,6 @@
   import { invalidateAll, validateInput, validateResults } from '$lib/stores/invalidation';
 
   onMount(() => {
-    // Mark stores as initialized after the first render
     isDesiredSpeedInitialized = true;
     previousDesiredSpeed = $desiredSpeed;
     isDirectionInitialized = true;
@@ -29,7 +29,11 @@
   let showDemoModal = false;
   let showImportModal = false;
   let pendingImportData = null;
-  
+
+  // Per-operation loading flags (global $isLoading stays for disabling buttons)
+  let isExtracting = false;
+  let isOptimizing = false;
+
   // Signal modal state
   let selectedSignal = null;
   let selectedSignalContext = null;
@@ -52,18 +56,17 @@
     : '';
 
   $: isExtractDisabled = $isLoading || $junctions.length < 2 || hasValidationError;
-  
-  // Helper: Check if we're in "clean" state (no data loss risk)
+
   $: isCleanState = $junctions.length === 0 && !hasGreenWaveData;
-  
+
   // Extract green waves from API
   async function handleExtractWaves() {
     if (isExtractDisabled) return;
-    
     try {
+      isExtracting = true;
       isLoading.set(true);
       error.set(null);
-      
+
       const junctionsForAPI = prepareJunctionsForAPI($junctions);
       const response = await extractGreenWaves(junctionsForAPI, $desiredSpeed, $optimizationDirection);
       originalGreenWaves.set(response.green_waves || []);
@@ -72,41 +75,37 @@
       originalReverseThroughWaves.set(response.reverse_through_green_waves || []);
       showGreenWaves.set(true);
       storeWaveCalculationPositions($junctions, $desiredSpeed);
-
       validateInput();
     } catch (apiError) {
       error.set(apiError.message || 'Failed to extract green waves');
       console.error('API Error:', apiError);
     } finally {
+      isExtracting = false;
       isLoading.set(false);
     }
   }
-  
+
   // Smart modal handlers
   function handleResetClick() {
     if (isCleanState) {
-      // Already clean - no need to confirm
       resetToEmpty();
     } else {
-      // Has data - show confirmation
       showResetModal = true;
     }
   }
-  
+
   function handleDemoDataClick() {
     if (isCleanState) {
-      // No data to lose - load directly
       resetToDemo();
     } else {
-      // Has data - show confirmation
       showDemoModal = true;
     }
   }
-  
+
   function confirmReset() {
     resetToEmpty();
   }
-  
+
   function confirmDemoData() {
     resetToDemo();
   }
@@ -146,14 +145,12 @@
     }, 100);
   }
 
-
   let debounceTimeout;
-  // Update the store with new distance
   function updateJunction(event) {
     const { id, newDistance } = event.detail;
     clearTimeout(debounceTimeout);
     debounceTimeout = setTimeout(() => {
-    junctions.update(junctionList => {
+      junctions.update(junctionList => {
         return junctionList.map(junction => {
           if (junction.id === id) {
             return { ...junction, point: { ...junction.point, y: newDistance } };
@@ -167,20 +164,18 @@
 
   // Handle optimization
   async function handleOptimize() {
+    if (isExtractDisabled) return;
     try {
+      isOptimizing = true;
       isLoading.set(true);
       error.set(null);
 
       const junctionsForAPI = prepareJunctionsForAPI($junctions);
       const optimizeResponse = await optimizeOffsets(junctionsForAPI, $desiredSpeed, 'genetic', {}, $optimizationDirection);
 
-      // Update the store with optimized offsets
       optimizedOffsets.set(optimizeResponse.best_offsets || []);
-
-      // Handle the optimization response
       optimizedJunctions.set(applyOffsetsToJunctions($junctions, optimizeResponse.best_offsets));
 
-      // Extract the optimized green waves
       const optimizedJunctionsForAPI = prepareJunctionsForAPI($optimizedJunctions);
       const response = await extractGreenWaves(optimizedJunctionsForAPI, $desiredSpeed, $optimizationDirection);
       optimizedGreenWaves.set(response.green_waves || []);
@@ -188,15 +183,14 @@
       optimizedReverseGreenWaves.set(response.reverse_green_waves || []);
       optimizedReverseThroughWaves.set(response.reverse_through_green_waves || []);
 
-      // Store the current state for validation
       optimizedWaveCalculationPositions.set($junctions.map(j => ({ id: j.id, y: j.point.y })));
       optimizedLastCalculatedSpeed.set($desiredSpeed);
-
-      validateResults()
+      validateResults();
     } catch (optimizeError) {
       error.set(optimizeError.message || 'Failed to optimize');
       console.error('Optimize Error:', optimizeError);
     } finally {
+      isOptimizing = false;
       isLoading.set(false);
     }
   }
@@ -214,16 +208,11 @@
   function saveSignal(e) {
     const updatedSignal = e.detail.signal;
 
-    console.log("Saving signal:", updatedSignal);
-    console.log("Selected signal context:", selectedSignalContext);
-
-    // Ensure selectedSignalContext has the full context
     if (!selectedSignalContext || !selectedSignalContext.junction || !selectedSignalContext.phase) {
       console.error("Invalid selectedSignalContext:", selectedSignalContext);
       return;
     }
 
-    // Update the signal in the corresponding junction
     junctions.update((junctionList) => {
       const updatedJunctions = junctionList.map((junction) => {
         if (junction.id === selectedSignalContext.junction.id) {
@@ -250,21 +239,16 @@
         }
         return junction;
       });
-
-      return updatedJunctions; // Reassign the store to trigger reactivity
+      return updatedJunctions;
     });
 
     invalidateAll('signal changes');
-
-    // Close the modal
     closeSignalModal();
   }
 
   function openSignalModal(event) {
     const { junction, phase, signal } = event.detail;
-    // Store the context for saving
     selectedSignalContext = { junction, phase };
-    // Pass only the signal to the modal
     selectedSignal = signal;
     isSignalModalOpen = true;
   }
@@ -274,10 +258,8 @@
     isSignalModalOpen = false;
   }
 
-  // Junction modal handlers
   function openJunctionModal(event) {
     const { junction } = event.detail;
-    // Find the original junction from the store (not the one with calculated total_duration)
     const originalJunction = $junctions.find(j => j.id === junction.id);
     selectedJunction = originalJunction || junction;
     isNewJunction = false;
@@ -285,7 +267,6 @@
   }
 
   function openNewJunctionModal() {
-    // Create a new junction with default values
     const maxId = $junctions.length > 0 ? Math.max(...$junctions.map(j => j.id)) : -1;
     const maxY = $junctions.length > 0 ? Math.max(...$junctions.map(j => j.point.y)) : -100;
 
@@ -310,17 +291,13 @@
 
   function saveJunction(event) {
     const { junction, isNew } = event.detail;
-
     if (isNew) {
-      // Add new junction
       junctions.update(junctionList => [...junctionList, junction]);
     } else {
-      // Update existing junction
       junctions.update(junctionList =>
         junctionList.map(j => j.id === junction.id ? junction : j)
       );
     }
-
     invalidateAll('junction configuration changed');
     closeJunctionModal();
   }
@@ -336,11 +313,6 @@
     selectedJunction = null;
     isJunctionModalOpen = false;
     isNewJunction = false;
-  }
-
-  function startDiagram() {
-    console.log("Starting diagram with empty junctions");
-    junctions.set([]);
   }
 
   // File menu items
@@ -373,14 +345,12 @@
           }
 
           if (isCleanState) {
-            // No data to lose - import directly
             junctions.set(imported.junctions);
             if (imported.desiredSpeed) desiredSpeed.set(imported.desiredSpeed);
             if (imported.desiredIntensity) desiredIntensity.set(imported.desiredIntensity);
             if (imported.direction) optimizationDirection.set(imported.direction);
             invalidateAll('configuration imported');
           } else {
-            // Has data - show confirmation
             pendingImportData = imported;
             showImportModal = true;
           }
@@ -405,11 +375,10 @@
         break;
     }
   }
-
 </script>
 
-<!-- Reset Confirmation Modal -->
-<ConfirmModal 
+<!-- Confirmation Modals -->
+<ConfirmModal
   bind:show={showResetModal}
   title="Reset All Data"
   message="This will clear all junctions, reset the desired speed, and remove all calculated results. This action cannot be undone."
@@ -419,7 +388,6 @@
   danger={true}
 />
 
-<!-- Demo Data Confirmation Modal -->
 <ConfirmModal
   bind:show={showDemoModal}
   title="Load Demo Data"
@@ -430,7 +398,6 @@
   danger={false}
 />
 
-<!-- Import Confirmation Modal -->
 <ConfirmModal
   bind:show={showImportModal}
   title="Import Configuration"
@@ -461,234 +428,115 @@
 
 <div class="min-h-screen bg-gray-50 flex flex-col">
   <div class="container mx-auto p-4 flex-1 flex flex-col">
+
     <!-- Header -->
     <div class="mb-6">
       <h1 class="text-3xl font-bold text-center mb-4">Green Wave Traffic Light Optimizer</h1>
-      
-      <!-- Error Message -->
+
+      <!-- Error banner -->
       {#if $error}
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          <strong>Error:</strong> {$error}
+        <div
+          transition:slide={{ duration: 200 }}
+          class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-md mb-4 flex justify-between items-start gap-3"
+        >
+          <span><strong>Error:</strong> {$error}</span>
+          <button
+            on:click={() => error.set(null)}
+            class="text-red-500 hover:text-red-700 leading-none shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 rounded"
+            aria-label="Dismiss error"
+          >✕</button>
         </div>
       {/if}
     </div>
-    
-    <!-- Main content grid -->
+
+    <!-- Main content grid  Input LEFT, Results RIGHT -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 flex-1 min-h-0">
-      <!-- Left side - optimized results -->
-      <div class="bg-white rounded-lg shadow-md p-6 flex flex-col flex-1 min-h-0">
-        <div class="flex justify-between items-center mb-4">
-          <h2 class="text-xl font-semibold">Optimized results</h2>
-          <button
-            on:click={clearResults}
-            class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 text-sm w-24 text-center"
-            >
-            Clear results
-          </button>
-        </div>
-        
-        <!-- Results chart container -->
-        <div class="flex-1 border border-gray-300 rounded-lg mb-4 min-h-0 overflow-hidden">
-          {#if $optimizedJunctions.length > 0}
-            <TimeSpaceDiagram
-              junctions={$optimizedJunctions}
-              greenWaves={$optimizedGreenWaves}
-              throughWaves={$optimizedThroughWaves}
-              reverseGreenWaves={$optimizedReverseGreenWaves}
-              reverseThroughWaves={$optimizedReverseThroughWaves}
-              showWaves={true}
-              interactive={false}
-              resultsAreOutdated={$optimizedResultsAreOutdated}
-              isResults={true}
-            />
-          {:else}
-            <div class="flex items-center border-2 border-dashed border-gray-300 rounded-lg justify-center h-full text-gray-500">
-              <p>No optimized results to display. Run optimization to see results.</p>
-            </div>
-          {/if}
-        </div>
 
-        <!-- Controls for results -->
-        <div class="border-t pt-4 mt-auto">
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <!-- Desired intensity -->
-            <div>
-              <label for="opt-desired-intensity" class="block text-sm font-medium mb-2">Desired intensity (vehicles/hour)</label>
-              <input
-                id="opt-desired-intensity"
-                type="number"
-                bind:value={$desiredIntensity}
-                class="w-full px-3 py-2 border rounded-md"
-                min="0"
-                class:border-orange-500={hasResults && $optimizedResultsAreOutdated.isOutdated}
-                class:border-black-300={!hasResults || !$optimizedResultsAreOutdated.isOutdated}
-                disabled={hasResults && $optimizedResultsAreOutdated.isOutdated}
-              />
-            </div>
+      <!-- LEFT: Input Configuration -->
+      <div class="bg-white rounded-lg shadow-md p-6 flex flex-col min-h-0">
 
-            <!-- Desired Flow -->
-            <div>
-              <label for="opt-desired-flow" class="block text-sm font-medium mb-2">Desired flow (vehicles/second)</label>
-              <input
-                id="opt-desired-flow"
-                type="number"
-                value={$desiredFlow}
-                class="w-full px-3 py-2 border rounded-md"
-                min="0"
-                step="0.5"
-                class:border-orange-500={hasResults && $optimizedResultsAreOutdated.isOutdated}
-                class:border-black-300={!hasResults || !$optimizedResultsAreOutdated.isOutdated}
-                on:input={(e) => desiredIntensity.set(e.target.value * 3600)}
-                disabled={hasResults && $optimizedResultsAreOutdated.isOutdated}
-              />
-            </div>
-
-            <!-- Actual Intensity (Forward) -->
-            <div>
-              <span class="block text-sm font-medium mb-2">
-                Actual intensity{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}
-              </span>
-              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                {($actualIntensityOptimized || 0).toFixed(2)} veh/h
-                {#if hasResults && $optimizedResultsAreOutdated.isOutdated}
-                  <span class="text-orange-500">(Outdated)</span>
-                {/if}
-              </div>
-            </div>
-
-            <!-- Actual Flow (Forward) -->
-            <div>
-              <span class="block text-sm font-medium mb-2">
-                Actual flow{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}
-              </span>
-              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                {$actualFlowOptimized.toFixed(6)} veh/s
-                {#if hasResults && $optimizedResultsAreOutdated.isOutdated}
-                  <span class="text-orange-500">(Outdated)</span>
-                {/if}
-              </div>
-            </div>
-
-            {#if $optimizationDirection === 'bidirectional'}
-              <!-- Actual Intensity (Reverse) -->
-              <div>
-                <span class="block text-sm font-medium mb-2">
-                  Actual intensity <span class="text-blue-600">(rev)</span>
-                </span>
-                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                  {($actualReverseIntensityOptimized || 0).toFixed(2)} veh/h
-                  {#if hasResults && $optimizedResultsAreOutdated.isOutdated}
-                    <span class="text-orange-500">(Outdated)</span>
-                  {/if}
-                </div>
-              </div>
-
-              <!-- Actual Flow (Reverse) -->
-              <div>
-                <span class="block text-sm font-medium mb-2">
-                  Actual flow <span class="text-blue-600">(rev)</span>
-                </span>
-                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                  {$actualReverseFlowOptimized.toFixed(6)} veh/s
-                  {#if hasResults && $optimizedResultsAreOutdated.isOutdated}
-                    <span class="text-orange-500">(Outdated)</span>
-                  {/if}
-                </div>
-              </div>
-            {/if}
+        <!-- Panel header: title + wrapping toolbar -->
+        <div class="mb-4">
+          <div class="flex justify-between items-center mb-3">
+            <h2 class="text-xl font-semibold">Input configuration</h2>
           </div>
-        </div>
-      </div>
-      
-      <!-- Right side - Input Data -->
-      <div class="bg-white rounded-lg shadow-md p-6 flex flex-col flex-1 min-h-0">
-        <div class="flex justify-between items-center mb-4">
-          <h2 class="text-xl font-semibold">Input configuration</h2>
-          <div class="flex gap-4 items-center">
-            <div class="flex gap-2">
-              <DropdownMenu
-                label="File"
-                items={fileMenuItems}
-                on:select={handleFileMenuSelect}
-              />
+          <!-- Toolbar wraps on narrow panels instead of clipping -->
+          <div class="flex flex-wrap gap-2 items-center">
+            <DropdownMenu
+              label="File"
+              items={fileMenuItems}
+              on:select={handleFileMenuSelect}
+            />
 
-              <button
-                on:click={openNewJunctionModal}
-                class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm w-32 text-center"
-                title="Add a new junction"
-              >
-                + Add Junction
-              </button>
+            <button
+              on:click={openNewJunctionModal}
+              class="px-3 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-1"
+              title="Add a new junction"
+            >
+              + Add Junction
+            </button>
 
-              <button
-                on:click={handleExtractWaves}
-                disabled={isExtractDisabled}
-                class="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 text-sm disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-2 w-32"
-              >
-                {#if $isLoading}
-                  <div class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-                  Loading...
-                {:else}
-                  Extract waves
-                {/if}
-              </button>
+            <button
+              on:click={handleExtractWaves}
+              disabled={isExtractDisabled}
+              class="px-3 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 text-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-1"
+            >
+              {#if isExtracting}
+                <div class="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                Extracting...
+              {:else}
+                Extract waves
+              {/if}
+            </button>
 
-              <button
-                on:click={handleOptimize}
-                disabled={isExtractDisabled}
-                class="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm w-24 text-center disabled:bg-gray-400 disabled:cursor-not-allowed"
-                title="Recalculate waves and optimize offsets"
-              >
+            <button
+              on:click={handleOptimize}
+              disabled={isExtractDisabled}
+              class="px-3 py-2 bg-purple-500 text-white rounded-md hover:bg-purple-600 text-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-1"
+              title="Recalculate waves and optimize offsets"
+            >
+              {#if isOptimizing}
+                <div class="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                Optimizing...
+              {:else}
                 Optimize
-              </button>
-            </div>
-            
-            <!-- Toggle Group - Separate -->
-            <label class="flex items-center cursor-pointer">
-              <input 
-                type="checkbox" 
+              {/if}
+            </button>
+
+            <!-- Show waves toggle  padded for 44px touch target -->
+            <label class="flex items-center gap-2 cursor-pointer select-none py-2 px-1">
+              <input
+                type="checkbox"
                 bind:checked={$showGreenWaves}
                 disabled={!hasGreenWaveData}
-                class="mr-2"
-                class:opacity-50={!hasGreenWaveData}
-                class:cursor-not-allowed={!hasGreenWaveData}
+                class="w-4 h-4 cursor-pointer disabled:cursor-not-allowed"
               />
-              <span class="text-sm" class:text-gray-400={!hasGreenWaveData}>
-                Show waves
-              </span>
+              <span class="text-sm" class:text-gray-400={!hasGreenWaveData}>Show waves</span>
             </label>
           </div>
         </div>
-        
-        <!-- Chart container -->
-        <div class="flex-1 border border-gray-300 rounded mb-4 min-h-0 overflow-hidden">
+
+        <!-- Chart (flex-1 fills available space, controls sit below) -->
+        <div class="flex-1 border border-gray-300 rounded-md mb-1 min-h-[280px] overflow-hidden">
           {#if $junctions.length === 0}
-            <!-- Empty State -->
             <div class="flex items-center justify-center h-full text-gray-500">
-              <div class="text-center">
+              <div class="text-center p-6">
                 <svg class="w-16 h-16 mx-auto mb-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                 </svg>
                 <h3 class="text-lg font-medium mb-2">No junctions configured</h3>
                 <p class="text-sm mb-4">Add junctions to start visualizing traffic light coordination</p>
-                <div class="flex gap-2 justify-center">
-                  <button
-                    on:click={openNewJunctionModal}
-                    class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm"
-                  >
+                <div class="flex gap-2 justify-center flex-wrap">
+                  <button on:click={openNewJunctionModal} class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400">
                     + Add First Junction
                   </button>
-                  <button
-                    on:click={handleDemoDataClick}
-                    class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 text-sm"
-                  >
+                  <button on:click={handleDemoDataClick} class="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400">
                     Load Demo Data
                   </button>
                 </div>
               </div>
             </div>
           {:else}
-            <!-- Regular Chart -->
             <TimeSpaceDiagram
               junctions={$junctions}
               wavesAreOutdated={$wavesAreOutdated}
@@ -699,150 +547,209 @@
               reverseThroughWaves={$originalReverseThroughWaves}
               showWaves={$showGreenWaves}
               on:updateJunction={updateJunction}
-              isResults={false}
               on:editSignal={openSignalModal}
               on:editJunction={openJunctionModal}
             />
           {/if}
         </div>
-        
-        <!-- Controls -->
-        <div class="border-t pt-4 mt-auto">
-          <!-- Optimization direction -->
-          <div class="mb-4">
-            <label for="input-direction" class="block text-sm font-medium mb-2">Optimization direction</label>
-            <select
-              id="input-direction"
-              bind:value={$optimizationDirection}
-              class="w-full px-3 py-2 border rounded-md"
-            >
-              <option value="forward">Forward only</option>
-              <option value="bidirectional">Bidirectional</option>
-            </select>
-          </div>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
-            <!-- Desired speed -->
-            <div>
-              <label for="input-desired-speed" class="block text-sm font-medium mb-2">Desired speed (km/h)</label>
-              <input
-                id="input-desired-speed"
-                type="number"
-                bind:value={$desiredSpeed}
-                class="w-full px-3 py-2 border rounded-md"
-                min="10"
-                max="100"
-              />
-            </div>
-
-            <!-- Junctions -->
-            <div>
-              <span class="block text-sm font-medium mb-2">Junctions</span>
-              <p class="text-sm text-gray-600">{$junctions.length} junctions configured</p>
-
-              {#if $junctions.length === 0}
-                <p class="text-sm text-blue-600 mt-1">📍 Use File menu or add junctions manually</p>
-              {:else if $junctions.length === 1}
-                <p class="text-sm text-orange-600 mt-1">⚠️ Add at least 1 more junction to extract waves</p>
-              {:else if hasValidationError}
-                <p class="text-sm text-red-600 mt-1">⚠️ {validationErrorMessage}</p>
-              {:else if hasGreenWaveData}
-                <p class="text-sm text-green-600 mt-1">✓ Green waves calculated</p>
-              {:else}
-                <p class="text-sm text-orange-600 mt-1">Press "Extract waves" to calculate green waves</p>
-              {/if}
-            </div>
-          </div>
-
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
-            <!-- Desired intensity -->
-            <div>
-              <label for="input-desired-intensity" class="block text-sm font-medium mb-2">Desired intensity (vehicles/hour)</label>
-              <input
-                id="input-desired-intensity"
-                type="number"
-                bind:value={$desiredIntensity}
-                class="w-full px-3 py-2 border rounded-md"
-                min="0"
-                class:border-orange-500={$wavesAreOutdated.isOutdated}
-                class:border-black-300={!$wavesAreOutdated.isOutdated}
-                disabled={$wavesAreOutdated.isOutdated}
-              />
-            </div>
-
-            <!-- Desired flow -->
-            <div>
-              <label for="input-desired-flow" class="block text-sm font-medium mb-2">Desired flow (vehicles/second)</label>
-              <input
-                id="input-desired-flow"
-                type="number"
-                value={$desiredFlow}
-                class="w-full px-3 py-2 border rounded-md"
-                min="0"
-                step="0.5"
-                class:border-orange-500={$wavesAreOutdated.isOutdated}
-                class:border-black-300={!$wavesAreOutdated.isOutdated}
-                on:input={(e) => desiredIntensity.set(e.target.value * 3600)}
-                disabled={$wavesAreOutdated.isOutdated}
-              />
-            </div>
-
-            <!-- Actual intensity (Forward) -->
-            <div>
-              <span class="block text-sm font-medium mb-2">
-                Actual intensity{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}
-              </span>
-              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                {($actualIntensity || 0).toFixed(2)} veh/h
-                {#if $wavesAreOutdated.isOutdated}
-                  <span class="text-orange-500">(Outdated)</span>
-                {/if}
-              </div>
-            </div>
-
-            <!-- Actual flow (Forward) -->
-            <div>
-              <span class="block text-sm font-medium mb-2">
-                Actual flow{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}
-              </span>
-              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                {($actualFlow || 0).toFixed(6)} veh/s
-                {#if $wavesAreOutdated.isOutdated}
-                  <span class="text-orange-500">(Outdated)</span>
-                {/if}
-              </div>
-            </div>
-
-            {#if $optimizationDirection === 'bidirectional'}
-              <!-- Actual intensity (Reverse) -->
-              <div>
-                <span class="block text-sm font-medium mb-2">
-                  Actual intensity <span class="text-blue-600">(rev)</span>
-                </span>
-                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                  {($actualReverseIntensity || 0).toFixed(2)} veh/h
-                  {#if $wavesAreOutdated.isOutdated}
-                    <span class="text-orange-500">(Outdated)</span>
-                  {/if}
-                </div>
-              </div>
-
-              <!-- Actual flow (Reverse) -->
-              <div>
-                <span class="block text-sm font-medium mb-2">
-                  Actual flow <span class="text-blue-600">(rev)</span>
-                </span>
-                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700">
-                  {($actualReverseFlow || 0).toFixed(6)} veh/s
-                  {#if $wavesAreOutdated.isOutdated}
-                    <span class="text-orange-500">(Outdated)</span>
-                  {/if}
-                </div>
-              </div>
+        {#if $junctions.length > 0}
+          <div class="mb-3 text-xs text-gray-500 leading-relaxed">
+            {#if $wavesAreOutdated.isOutdated}
+              <span class="text-orange-600">⚠️ {$wavesAreOutdated.reason}</span>
+            {:else}
+              Drag junctions to reposition · Click junction label or circle to edit · Click signal line to change
             {/if}
           </div>
+        {/if}
+
+        <!-- Controls below chart -> space-y-4 for stable spacing, no mt-auto needed -->
+        <div class="border-t pt-4 space-y-4">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label for="input-direction" class="block text-sm font-medium mb-2">Optimization direction</label>
+              <select id="input-direction" bind:value={$optimizationDirection} class="w-full px-3 py-2 border rounded-md">
+                <option value="forward">Forward only</option>
+                <option value="bidirectional">Bidirectional</option>
+              </select>
+            </div>
+            <div>
+              <label for="input-desired-speed" class="block text-sm font-medium mb-2">Desired speed (km/h)</label>
+              <input id="input-desired-speed" type="number" bind:value={$desiredSpeed} class="w-full px-3 py-2 border rounded-md" min="10" max="100" />
+            </div>
+          </div>
+
+          <!-- Junction status -> own line so it never shifts the grid above -->
+          <div class="text-sm leading-snug">
+            <span class="font-medium text-gray-700">{$junctions.length} junctions</span>
+            {#if $junctions.length === 0}
+              <span class="text-blue-600"> -> use File menu or add manually</span>
+            {:else if $junctions.length === 1}
+              <span class="text-orange-600"> -> add at least 1 more to extract waves</span>
+            {:else if hasValidationError}
+              <span class="block text-red-600 mt-0.5">⚠ {validationErrorMessage}</span>
+            {:else if hasGreenWaveData}
+              <span class="text-green-600"> -> green waves calculated</span>
+            {:else}
+              <span class="text-orange-600"> -> press "Extract waves" to calculate</span>
+            {/if}
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label for="input-desired-intensity" class="block text-sm font-medium mb-2">Desired intensity (veh/h)</label>
+              <input id="input-desired-intensity" type="number" bind:value={$desiredIntensity} class="w-full px-3 py-2 border rounded-md" min="0" />
+            </div>
+            <div>
+              <label for="input-desired-flow" class="block text-sm font-medium mb-2">Desired flow (veh/s)</label>
+              <input id="input-desired-flow" type="number" value={$desiredFlow} class="w-full px-3 py-2 border rounded-md" min="0" step="0.5" on:input={(e) => desiredIntensity.set(e.target.value * 3600)} />
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <span class="block text-sm font-medium mb-2">Actual intensity{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}</span>
+              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                {($actualIntensity || 0).toFixed(2)} veh/h
+                {#if $wavesAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+              </div>
+            </div>
+            <div>
+              <span class="block text-sm font-medium mb-2">Actual flow{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}</span>
+              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                {($actualFlow || 0).toFixed(6)} veh/s
+                {#if $wavesAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+              </div>
+            </div>
+          </div>
+
+          {#if $optimizationDirection === 'bidirectional'}
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <span class="block text-sm font-medium mb-2">Actual intensity <span class="text-blue-600">(rev)</span></span>
+                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                  {($actualReverseIntensity || 0).toFixed(2)} veh/h
+                  {#if $wavesAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+                </div>
+              </div>
+              <div>
+                <span class="block text-sm font-medium mb-2">Actual flow <span class="text-blue-600">(rev)</span></span>
+                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                  {($actualReverseFlow || 0).toFixed(6)} veh/s
+                  {#if $wavesAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+                </div>
+              </div>
+            </div>
+          {/if}
         </div>
       </div>
+
+      <!-- RIGHT: Optimized Results -->
+      <div class="bg-white rounded-lg shadow-md p-6 flex flex-col min-h-0">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-xl font-semibold">Optimized results</h2>
+          <button
+            on:click={clearResults}
+            class="px-3 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
+          >
+            Clear results
+          </button>
+        </div>
+
+        <!-- Chart (flex-1 fills available space, controls sit below) -->
+        <div class="flex-1 border border-gray-300 rounded-md mb-1 min-h-[280px] overflow-hidden">
+          {#if $optimizedJunctions.length > 0}
+            <TimeSpaceDiagram
+              junctions={$optimizedJunctions}
+              greenWaves={$optimizedGreenWaves}
+              throughWaves={$optimizedThroughWaves}
+              reverseGreenWaves={$optimizedReverseGreenWaves}
+              reverseThroughWaves={$optimizedReverseThroughWaves}
+              showWaves={true}
+              interactive={false}
+            />
+          {:else}
+            <div class="flex items-center border-2 border-dashed border-gray-300 rounded-md justify-center h-full text-gray-500 p-6">
+              <p class="text-center text-sm">No optimized results yet. Configure input and press Optimize.</p>
+            </div>
+          {/if}
+        </div>
+
+        {#if $optimizedJunctions.length > 0}
+          <div class="mb-3 text-xs text-gray-500 leading-relaxed">
+            {#if $optimizedResultsAreOutdated.isOutdated}
+              <span class="text-orange-600">⚠️ {$optimizedResultsAreOutdated.reason}</span>
+            {:else}
+              Press Optimize to recalculate with current settings
+            {/if}
+          </div>
+        {/if}
+
+        <!-- Controls below chart -> space-y-4 for stable spacing, no mt-auto needed -->
+        <div class="border-t pt-4 space-y-4">
+          <!-- Optimization status -> own line, wraps freely -->
+          <div class="text-sm leading-snug">
+            {#if $optimizedJunctions.length > 0}
+              <span class="font-medium text-gray-700">{$optimizedJunctions.length} junctions optimized</span>
+              {#if $optimizedResultsAreOutdated.isOutdated}
+                <span class="block text-orange-600 mt-0.5">⚠ {$optimizedResultsAreOutdated.reason}</span>
+              {:else}
+                <span class="text-green-600"> -> offsets applied</span>
+              {/if}
+            {:else}
+              <span class="text-gray-400">No results yet -> press Optimize</span>
+            {/if}
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label for="opt-desired-intensity" class="block text-sm font-medium mb-2">Desired intensity (veh/h)</label>
+              <input id="opt-desired-intensity" type="number" bind:value={$desiredIntensity} class="w-full px-3 py-2 border rounded-md" min="0" />
+            </div>
+            <div>
+              <label for="opt-desired-flow" class="block text-sm font-medium mb-2">Desired flow (veh/s)</label>
+              <input id="opt-desired-flow" type="number" value={$desiredFlow} class="w-full px-3 py-2 border rounded-md" min="0" step="0.5" on:input={(e) => desiredIntensity.set(e.target.value * 3600)} />
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <span class="block text-sm font-medium mb-2">Actual intensity{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}</span>
+              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                {($actualIntensityOptimized || 0).toFixed(2)} veh/h
+                {#if hasResults && $optimizedResultsAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+              </div>
+            </div>
+            <div>
+              <span class="block text-sm font-medium mb-2">Actual flow{#if $optimizationDirection === 'bidirectional'} <span class="text-green-600">(fwd)</span>{/if}</span>
+              <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                {$actualFlowOptimized.toFixed(6)} veh/s
+                {#if hasResults && $optimizedResultsAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+              </div>
+            </div>
+          </div>
+
+          {#if $optimizationDirection === 'bidirectional'}
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <span class="block text-sm font-medium mb-2">Actual intensity <span class="text-blue-600">(rev)</span></span>
+                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                  {($actualReverseIntensityOptimized || 0).toFixed(2)} veh/h
+                  {#if hasResults && $optimizedResultsAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+                </div>
+              </div>
+              <div>
+                <span class="block text-sm font-medium mb-2">Actual flow <span class="text-blue-600">(rev)</span></span>
+                <div class="w-full px-3 py-2 border rounded-md bg-gray-100 text-gray-700 tabular-nums">
+                  {$actualReverseFlowOptimized.toFixed(6)} veh/s
+                  {#if hasResults && $optimizedResultsAreOutdated.isOutdated}<span class="text-orange-500 text-xs">(outdated)</span>{/if}
+                </div>
+              </div>
+            </div>
+          {/if}
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/web/greenwave-ui/src/routes/+page.svelte
+++ b/web/greenwave-ui/src/routes/+page.svelte
@@ -675,13 +675,9 @@
           {/if}
         </div>
 
-        {#if $optimizedJunctions.length > 0}
+        {#if $optimizedJunctions.length > 0 && !$optimizedResultsAreOutdated.isOutdated}
           <div class="mb-3 text-xs text-gray-500 leading-relaxed">
-            {#if $optimizedResultsAreOutdated.isOutdated}
-              <span class="text-orange-600">⚠️ {$optimizedResultsAreOutdated.reason}</span>
-            {:else}
-              Press Optimize to recalculate with current settings
-            {/if}
+            Press Optimize to recalculate with current settings
           </div>
         {/if}
 


### PR DESCRIPTION
By mistake there is https://github.com/LdDl/greenwave/pull/7 (which I've accidentally merged, when work had not been done). The base is intentionally https://github.com/LdDl/greenwave/tree/feature/smoothingMP because of some changes to the HTTP API

## What changed

- Swap panels: inputs are on the left, results - right
- Fix D3 chart resize: `chartWidth/chartHeight` were `const`, scales stayed frozen on resize - changed to `let`, recalculated in `updateSize()`
- Controls below chart use `space-y-4` + stable 2-col grids - no more layout shifts when junction status/errors appear
- Toolbar wraps on narrow viewports (`flex-wrap`) instead of clipping
- Replaced `alert()`/`confirm()` in EditJunctionModal with inline validation and inline delete confirmation
- Modal transitions: `fade` on backdrop, `scale` on card
- Restored desired intensity/flow inputs to Results panel (same stores, editable)
- Added offset labels to results chart.